### PR TITLE
Field map checks

### DIFF
--- a/cmd/mrfieldunwarp.cpp
+++ b/cmd/mrfieldunwarp.cpp
@@ -28,13 +28,22 @@ void usage ()
 
   SYNOPSIS = "Unwarp an EPI image according to its susceptibility field.";
 
+  DESCRIPTION
+    + "This command takes EPI data and a field map in Hz, and inverts the distortion introduced "
+      "by the B0 field inhomogeneity. The command can also take motion parameters for each volume "
+      "or slice, but does not invert the motion. The motion parameters are only used to align the "
+      "field with the moving subject."
+
+    + "If the field map is estimated using FSL Topup, make sure to use the --fmap output "
+      "(the field map in Hz) instead of the spline coefficient representation saved by default.";
+
   ARGUMENTS
     + Argument ("input",
                 "the input image.").type_image_in ()
     + Argument ("field",
-                "the B0 field.").type_file_in ()
+                "the B0 field map in Hz.").type_file_in ()
     + Argument ("output",
-                "the output, field unwrapped, image.").type_image_out ();
+                "the field-unwrapped image.").type_image_out ();
 
   OPTIONS
     + Option ("motion",

--- a/cmd/mrfieldunwarp.cpp
+++ b/cmd/mrfieldunwarp.cpp
@@ -132,6 +132,11 @@ void run ()
 {
   auto data = Image<value_type>::open(argument[0]);
   auto field = Image<value_type>::open(argument[1]);
+  if (not voxel_grids_match_in_scanner_space(data, field)) {
+    WARN("Field map voxel grid does not match the input data. "
+         "If the field map was estimated using FSL TOPUP, make sure to use the --fmap output "
+         "(the field map in Hz) instead of the spline coefficient representation.");
+  }
 
   auto petable = PhaseEncoding::get_scheme(data);
   if (petable.rows() != data.size(3))


### PR DESCRIPTION
Show a warning when the field map voxel grid does not match that of the input data. Using a field map with different voxel size or header transform is allowed, to support using B0 scans. However, when used in combination with FSL Topup, mismatched dimensions between field map and data can mean that the user has accidentally passed the output spline representation to `mrfieldunwarp`, instead of the field map in Hz (Topup `--fmap` output).