### PR TITLE
dwimotioncorrect: read rlmax from config file

### DIFF
--- a/bin/dwimotioncorrect
+++ b/bin/dwimotioncorrect
@@ -276,9 +276,10 @@ def execute(): #pylint: disable=unused-variable
     def rankreduxstep(k, conf):
         lboption = ' -lbreg {}'.format(conf['lbreg']) if conf['lbreg']>0 else ''
         fwhmoption = ' -fwhm {}'.format(round(vu*conf['reg-scale'], 2))
-        redrfs = ['redrf'+str(k+1)+'.txt' for k in range(len(conf['rlmax']))]
+        rlmax = [min(r,l) for r, l in zip(conf['rlmax'], sorted(lmax, reverse=True))]
+        redrfs = ['redrf'+str(k+1)+'.txt' for k in range(len(rlmax))]
         run.command('mrfilter recon-' + str(k) + '.mif smooth -' + fwhmoption + ' | ' +
-                    'msshsvd - -mask mask.mif -lmax ' + ','.join([str(l) for l in conf['rlmax']]) +
+                    'msshsvd - -mask mask.mif -lmax ' + ','.join(map(str, rlmax)) +
                     lboption + ' ' + ' '.join(redrfs) + ' -proj rankredux.mif -force')
 
 

--- a/bin/dwimotioncorrect
+++ b/bin/dwimotioncorrect
@@ -30,6 +30,7 @@ DEFAULT_CONFIG = """{
     "rec-iter": 3,
     "reg-iter": 10,
     "reg-scale": 1.0,
+    "rlmax": [2,2,0],
     "lbreg": 0.0
   },
   "epochs": [
@@ -81,7 +82,7 @@ def usage(cmdline): #pylint: disable=unused-variable
     options.add_argument('-priorweights', help='Import prior slice weights')
     options.add_argument('-fixedweights', help='Import fixed slice weights')
     options.add_argument('-fixedmotion', help='Import fixed motion traces')
-    options.add_argument('-voxelweights', help='Import fixed voxel weights')    
+    options.add_argument('-voxelweights', help='Import fixed voxel weights')
     options.add_argument('-export_motion', help='Export rigid motion parameters')
     options.add_argument('-export_weights', help='Export slice weights')
     app.add_dwgrad_import_options(cmdline)
@@ -133,6 +134,16 @@ def execute(): #pylint: disable=unused-variable
     else:
         run.command('dwi2mask in.mif mask.mif')
 
+    # Configuration
+    config = json.loads(DEFAULT_CONFIG)
+    if app.ARGS.setup:
+        with open(path.from_user(app.ARGS.setup, True)) as f:
+            customconfig = json.load(f)
+            # use defaults for unspecified config options
+            customconfig['global'] = {**config['global'], **customconfig['global']}
+            # update config
+            config.update(customconfig)
+
     # Image dimensions
     dims = list(map(int, header.size()))
     vox = list(map(float, header.spacing()))
@@ -146,21 +157,11 @@ def execute(): #pylint: disable=unused-variable
     if len(lmax) != len(shells):
         raise MRtrixError('No. lmax must match no. shells.')
 
-    rlmax = [2,2,0]
     if app.ARGS.rlmax:
         rlmax = [int(l) for l in app.ARGS.rlmax.split(',')]
-    if len(rlmax) > len(lmax) or max(rlmax) > max(lmax):
-        raise MRtrixError('-rlmax invalid.')
-
-    # Configuration
-    config = json.loads(DEFAULT_CONFIG)
-    if app.ARGS.setup:
-        with open(path.from_user(app.ARGS.setup, True)) as f:
-            customconfig = json.load(f)
-            # use defaults for unspecified config options
-            customconfig['global'] = {**config['global'], **customconfig['global']}
-            # update config
-            config.update(customconfig)
+        config['global']['rlmax'] = rlmax
+    if len(config['global']['rlmax']) > len(lmax) or max(config['global']['rlmax']) > max(lmax):
+            raise MRtrixError('-rlmax invalid.')
 
     # Override regularization options if provided
     if app.ARGS.reg:
@@ -185,8 +186,6 @@ def execute(): #pylint: disable=unused-variable
                 i = '1' if k==s else '0'
                 f.write(' '.join([i,]*(l//2+1)) + '\n')
         rfs += [fn,]
-
-    redrfs = ['redrf'+str(k+1)+'.txt' for k in range(len(rlmax))]
 
     # Force max no. threads
     nthr = ''
@@ -218,7 +217,7 @@ def execute(): #pylint: disable=unused-variable
         # mrcalc "hack" to check image dimensions & copy PE table
         run.command('mrcalc in.mif 0 -mult ' + path.from_user(app.ARGS.voxelweights, True) + ' -add voxelweights.mif')
 
-    
+
     # Variable input file name
     global inputfn, voxweightsfn
     inputfn = 'in.mif'
@@ -262,8 +261,9 @@ def execute(): #pylint: disable=unused-variable
     def rankreduxstep(k, conf):
         lboption = ' -lbreg {}'.format(conf['lbreg']) if conf['lbreg']>0 else ''
         fwhmoption = ' -fwhm {}'.format(round(vu*conf['reg-scale'], 2))
+        redrfs = ['redrf'+str(k+1)+'.txt' for k in range(len(conf['rlmax']))]
         run.command('mrfilter recon-' + str(k) + '.mif smooth -' + fwhmoption + ' | ' +
-                    'msshsvd - -mask mask.mif -lmax ' + ','.join([str(l) for l in rlmax]) +
+                    'msshsvd - -mask mask.mif -lmax ' + ','.join([str(l) for l in conf['rlmax']]) +
                     lboption + ' ' + ' '.join(redrfs) + ' -proj rankredux.mif -force')
 
 

--- a/bin/dwimotioncorrect
+++ b/bin/dwimotioncorrect
@@ -30,7 +30,6 @@ DEFAULT_CONFIG = """{
     "rec-iter": 3,
     "reg-iter": 10,
     "reg-scale": 1.0,
-    "rlmax": [4,2,0],
     "lbreg": 0.001
   },
   "epochs": [
@@ -169,12 +168,10 @@ def execute(): #pylint: disable=unused-variable
         raise MRtrixError('No. lmax must match no. shells.')
 
     # Set rlmax
-    rlmax = [min(r,max(l-2,0)) for r, l in zip(config['global']['rlmax'], sorted(lmax, reverse=True))]
     if app.ARGS.rlmax:
-        rlmax = [int(l) for l in app.ARGS.rlmax.split(',')]
-    if len(rlmax) > len(lmax) or max(rlmax) > max(lmax):
-            raise MRtrixError('-rlmax invalid.')
-    config['global']['rlmax'] = rlmax
+        config['global']['rlmax'] = [int(l) for l in app.ARGS.rlmax.split(',')]
+    if 'rlmax' not in config['global']:
+        config['global']['rlmax'] = [min(r,max(l-2,0)) for r, l in zip([4,2,0], sorted(lmax, reverse=True))]
 
     # Override regularization options if provided
     if app.ARGS.reg:


### PR DESCRIPTION
moved `rlmax` to global config to allow epoch-specific definition of `rlmax`

(this PR also includes #8)