### PR TITLE
dwimotioncorrect: use mssh as reference for command history

### DIFF
--- a/bin/dwimotioncorrect
+++ b/bin/dwimotioncorrect
@@ -81,7 +81,7 @@ def usage(cmdline): #pylint: disable=unused-variable
     options.add_argument('-priorweights', help='Import prior slice weights')
     options.add_argument('-fixedweights', help='Import fixed slice weights')
     options.add_argument('-fixedmotion', help='Import fixed motion traces')
-    options.add_argument('-voxelweights', help='Import fixed voxel weights')    
+    options.add_argument('-voxelweights', help='Import fixed voxel weights')
     options.add_argument('-export_motion', help='Export rigid motion parameters')
     options.add_argument('-export_weights', help='Export slice weights')
     app.add_dwgrad_import_options(cmdline)
@@ -218,7 +218,7 @@ def execute(): #pylint: disable=unused-variable
         # mrcalc "hack" to check image dimensions & copy PE table
         run.command('mrcalc in.mif 0 -mult ' + path.from_user(app.ARGS.voxelweights, True) + ' -add voxelweights.mif')
 
-    
+
     # Variable input file name
     global inputfn, voxweightsfn
     inputfn = 'in.mif'
@@ -310,8 +310,8 @@ def execute(): #pylint: disable=unused-variable
 
 
     #   __________ Copy outputs __________
-    
-    run.command('mrconvert recon-'+str(nepochs)+'.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval='NULL', force=app.FORCE_OVERWRITE)
+
+    run.command('mrconvert recon-'+str(nepochs)+'.mif ' + path.from_user(app.ARGS.output), mrconvert_keyval='recon-'+str(nepochs)+'.mif', force=app.FORCE_OVERWRITE)
     if app.ARGS.export_motion:
         run.command('cp motion.txt ' + path.from_user(app.ARGS.export_motion, True))
     if app.ARGS.export_weights:


### PR DESCRIPTION
partially reverts 0ce8a113dbc1b5512c73de1d42e489f06cfa106f

- to preserve header entries required for mssh2amp
- to preserve other properties propagated from input dwi header

