### PR TITLE
dwirecon: remove deprecated Loop({4,3}) syntax

### DIFF
--- a/cmd/dwirecon.cpp
+++ b/cmd/dwirecon.cpp
@@ -303,15 +303,10 @@ void run ()
 
   // Read input data to vector (this enforces positive strides!)
   Eigen::VectorXf y (R.rows()); y.setZero();
-  size_t j = 0, v = 0;
-  for (auto lv = Loop("loading image data", 3)(dwisub); lv; lv++, v++) {
-    size_t z = 0;
-    for (auto lz = Loop(2)(dwisub); lz; lz++, z++) {
-      float ww = std::sqrt(Wsub(z,v));
-      for (auto lxy = Loop({0,1})(dwisub); lxy; lxy++, j++) {
-        y[j] = ww * std::sqrt(Wvox[j]) * dwisub.value();
-      }
-    }
+  size_t j = 0;
+  for (auto lv = Loop("loading image data", {0, 1, 2, 3})(dwisub); lv; lv++, j++) {
+      float w = Wsub(size_t(dwisub.index(2)), size_t(dwisub.index(3))) * Wvox[j];
+      y[j] = std::sqrt(w) * dwisub.value();
   }
 
   // Fit scattered data in basis...

--- a/cmd/dwirecon_proj.cpp
+++ b/cmd/dwirecon_proj.cpp
@@ -201,8 +201,8 @@ void run ()
     auto mssh2x = x2mssh.fullPivHouseholderQr();
     for (auto l = Loop("loading initialisation", 0, 3) (init, recon); l; l++) {
       size_t k = 0;
-      for (auto l2 = Loop({4,3})(init); l2; l2++) {
-        if (init.index(4) < Math::SH::NforL(lmax))
+      for (auto l2 = Loop(3)(init); l2; l2++) {
+        for (init.index(4) = 0; init.index(4) < Math::SH::NforL(lmax); init.index(4)++)
           c[k++] = std::isfinite((float) init.value()) ? init.value() : 0.0f;
       }
       r = mssh2x.solve(c);


### PR DESCRIPTION
Consequence of https://github.com/MRtrix3/mrtrix3/pull/2170. Though flagged a while ago (#8), the issue was apparently not resolved completely. This caused an incompatibility at compile time with the dev branch in MRtrix.