### PR TITLE
Remove handling of incorrect bvec import - now fixed in MRtrix3

### DIFF
--- a/bin/dwimotioncorrect
+++ b/bin/dwimotioncorrect
@@ -150,7 +150,8 @@ def execute(): #pylint: disable=unused-variable
         for l in range(0,10,2):
             if (l+3)*(l+4)/2 * oversampling_factor > N:
                 return l
- 
+        return 10
+
     lmax = [(b>10) * get_max_sh_degree(n) for b, n in zip(shells, shell_sizes)]
     if app.ARGS.lmax:
         lmax = [int(l) for l in app.ARGS.lmax.split(',')]
@@ -204,7 +205,7 @@ def execute(): #pylint: disable=unused-variable
     nthr = ''
     if app.ARGS.nthreads:
         nthr = ' -nthreads ' + str(app.ARGS.nthreads)
-        
+
     # Set multiband factor
     mb = 1
     if app.ARGS.mb:

--- a/cmd/dwirecon.cpp
+++ b/cmd/dwirecon.cpp
@@ -55,7 +55,7 @@ void usage ()
   + Option ("rf", "Basis functions for the radial (multi-shell) domain, provided as matrices in which "
                   "rows correspond with shells and columns with SH harmonic bands.").allow_multiple()
     + Argument ("b").type_file_in()
-  
+
   + Option ("lmax", "The maximum harmonic order for the output series. (default = " + str(DEFAULT_LMAX) + ")")
     + Argument ("order").type_integer(0, 30)
 
@@ -130,7 +130,7 @@ void run ()
   if (opt.size())
     motion = load_matrix<float>(opt[0][0]);
   else
-    motion = Eigen::MatrixXf::Zero(dwi.size(3), 6); 
+    motion = Eigen::MatrixXf::Zero(dwi.size(3), 6);
 
   // Check dimensions
   if (motion.size() && motion.cols() != 6)
@@ -175,14 +175,11 @@ void run ()
     auto petable = PhaseEncoding::get_scheme(dwi);
     PE = petable.leftCols<3>().cast<float>();
     PE.array().colwise() *= petable.col(3).array().cast<float>();
-    // -----------------------  // TODO: Eddy uses a reverse LR axis for storing
-    PE.col(0) *= -1;            // the PE table, akin to the gradient table.
-    // -----------------------  // Fix in the eddy import/export functions in core.
     fieldmap = Image<value_type>::open(opt[0][0]);
     fieldidx = opt[0][1];
   }
 
-  // Get volume indices 
+  // Get volume indices
   vector<size_t> idx;
   if (rf.empty()) {
     idx = shells.largest().get_volumes();
@@ -250,7 +247,7 @@ void run ()
     lmax = get_option_value("lmax", DEFAULT_LMAX);
   else
     lmax = std::min(lmax, (int) get_option_value("lmax", lmax));
-  
+
   float reg = get_option_value("reg", DEFAULT_REG);
   float zreg = get_option_value("zreg", DEFAULT_ZREG);
 

--- a/cmd/dwirecon_proj.cpp
+++ b/cmd/dwirecon_proj.cpp
@@ -56,7 +56,7 @@ void usage ()
   + Option ("rf", "Basis functions for the radial (multi-shell) domain, provided as matrices in which "
                   "rows correspond with shells and columns with SH harmonic bands.").allow_multiple()
     + Argument ("b").type_file_in()
-  
+
   + Option ("lmax", "The maximum harmonic order for the output series. (default = " + str(DEFAULT_LMAX) + ")")
     + Argument ("order").type_integer(0, 30)
 
@@ -93,7 +93,7 @@ void run ()
   if (opt.size())
     motion = load_matrix<float>(opt[0][0]);
   else
-    motion = Eigen::MatrixXf::Zero(dwi.size(3), 6); 
+    motion = Eigen::MatrixXf::Zero(dwi.size(3), 6);
 
   // Check dimensions
   if (motion.size() && motion.cols() != 6)
@@ -138,14 +138,11 @@ void run ()
     auto petable = PhaseEncoding::get_scheme(dwi);
     PE = petable.leftCols<3>().cast<float>();
     PE.array().colwise() *= petable.col(3).array().cast<float>();
-    // -----------------------  // TODO: Eddy uses a reverse LR axis for storing
-    PE.col(0) *= -1;            // the PE table, akin to the gradient table.
-    // -----------------------  // Fix in the eddy import/export functions in core.
     fieldmap = Image<value_type>::open(opt[0][0]);
     fieldidx = opt[0][1];
   }
 
-  // Get volume indices 
+  // Get volume indices
   vector<size_t> idx;
   if (rf.empty()) {
     idx = shells.largest().get_volumes();
@@ -177,7 +174,7 @@ void run ()
     lmax = get_option_value("lmax", DEFAULT_LMAX);
   else
     lmax = std::min(lmax, (int) get_option_value("lmax", lmax));
-  
+
   DWI::SVR::QSpaceBasis qbasis {grad.cast<float>(), lmax, rf, motion};
 
 

--- a/cmd/mrfieldunwarp.cpp
+++ b/cmd/mrfieldunwarp.cpp
@@ -150,9 +150,6 @@ void run ()
   auto petable = PhaseEncoding::get_scheme(data);
   if (petable.rows() != data.size(3))
     throw Exception ("Invalid PE table.");
-  // -----------------------  // TODO: Eddy uses a reverse LR axis for storing
-  petable.col(0) *= -1;       // the PE table, akin to the gradient table.
-  // -----------------------  // Fix in the eddy import/export functions in core.
 
   // Apply rigid rotation to field.
   auto opt = get_options("motion");


### PR DESCRIPTION
This is to remove the LR flip of the bvecs, which has now been fixed in core MRtrix3.